### PR TITLE
Added `attributedText` override to support attributed text properly.

### DIFF
--- a/Sources/SkyFloatingLabelTextField.swift
+++ b/Sources/SkyFloatingLabelTextField.swift
@@ -63,6 +63,7 @@ open class SkyFloatingLabelTextField: UITextField { // swiftlint:disable:this ty
     // MARK: Colors
 
     fileprivate var cachedTextColor: UIColor?
+    fileprivate var cachedAttributedText: NSAttributedString?
 
     /// A UIColor value that determines the text color of the editable text
     @IBInspectable
@@ -73,6 +74,21 @@ open class SkyFloatingLabelTextField: UITextField { // swiftlint:disable:this ty
         }
         get {
             return cachedTextColor
+        }
+    }
+
+    /// An `NSAttributedString` to display as the text field content
+    ///
+    /// **NOTE:** by setting this property to a non-nil value, changes to `textColor`
+    /// are ignored.
+    @IBInspectable
+    override dynamic open var attributedText: NSAttributedString? {
+        set {
+            cachedAttributedText = newValue
+            super.attributedText = newValue
+        }
+        get {
+            return cachedAttributedText
         }
     }
 
@@ -526,7 +542,11 @@ open class SkyFloatingLabelTextField: UITextField { // swiftlint:disable:this ty
         } else if hasErrorMessage {
             super.textColor = textErrorColor ?? errorColor
         } else {
-            super.textColor = cachedTextColor
+            if let attributedText = cachedAttributedText {
+                super.attributedText = attributedText
+            } else {
+                super.textColor = cachedTextColor
+            }
         }
     }
 


### PR DESCRIPTION
Adds support for using setting the `attributedText` property of the `UITextField`. 

Setting this value was always possible of course, but the logic of `SkyFloatingLabelTextField` in reaction to other changes (eg  `isEnabled`, active, not active etc) always calls `updateColors()` which in turn calls `updateTextColor()` which in setting the `textColor` value of the `UITextField` overrides any color attributes that have been set in the `attributedText`, making it basically unusable.

With this change, if `attributedText` is set to a non-nil value, any changes to `textColor` are ignored, and internally the attributed string will remain unchanged when `updateTextColor()` is called, except to set it to the error color in the case of an error.